### PR TITLE
Fix prompt for no consent

### DIFF
--- a/cookiebar-latest.js
+++ b/cookiebar-latest.js
@@ -408,7 +408,7 @@ function setupCookieBar() {
     });
 
     buttonNo.addEventListener('click', function() {
-      var txt = promptNoConsent.innerText;
+      var txt = promptNoConsent.textContent.trim();
       var confirm = window.confirm(txt);
       if (confirm === true) {
         removeCookie();


### PR DESCRIPTION
innerText isn't supported any more in Firefox and others, use textContent instead. Also trim the text to make a nicer prompt.
