### PR TITLE
fix incorrectly returned second char of cookieValue string.

### DIFF
--- a/cookiebar-latest.js
+++ b/cookiebar-latest.js
@@ -278,7 +278,7 @@ function setupCookieBar() {
     if (cookieValue == null) {
       return undefined;
     } else {
-      return decodeURI(cookieValue)[2];
+      return decodeURI(cookieValue[2]);
     }
   }
 


### PR DESCRIPTION
fix incorrectly returned second char of cookieValue string instead it should return second element of the array.
