### PR TITLE
Fixed typo in en.html

### DIFF
--- a/lang/en.html
+++ b/lang/en.html
@@ -17,7 +17,7 @@
             <i id='cookie-bar-privacy-page'>
             <br>To learn more about how this website uses cookies or localStorage, please read our <a rel='nofollow' id='cookie-bar-privacy-link' href=''>PRIVACY POLICY</a>.<br><br></i>
 
-            <br>By clicking <span>Allow cookies</span> you give your permission to this website to store small bits of data as on your device.
+            <br>By clicking <span>Allow cookies</span> you give your permission to this website to store small bits of data on your device.
             <i id='cookie-bar-no-consent'>
             <br>
             <br>By clicking <span>Disallow cookies</span>, <span id='cookie-bar-scrolling'>or by scrolling the page,</span> you deny your consent to store any cookies and localStorage data for this website, eventually deleting already stored cookies (some parts of the site may stop working properly).</i><br>


### PR DESCRIPTION
The word 'as' was incorrectly placed in the sentence.
