### PR TITLE
fix invalid CSS in cookiebar-altblack.css

### DIFF
--- a/cookiebar-altblack.css
+++ b/cookiebar-altblack.css
@@ -31,7 +31,7 @@
     background:      -o-linear-gradient(top,  rgba(30,30,30,0.95) 0, rgba(0,0,0,0.95) 100%);
     background:     -ms-linear-gradient(top,  rgba(30,30,30,0.95) 0, rgba(0,0,0,0.95) 100%);
     background:         linear-gradient(to bottom,  rgba(30,30,30,0.95) 0, rgba(0,0,0,0.95) 100%);
-    font-family: font-family: 'Open Sans', sans-serif;
+    font-family: 'Open Sans', sans-serif;
     font-size: 10pt !important;
     left: 0;
     line-height: 1.5;


### PR DESCRIPTION
The `cookiebar-altblack.css` file contains an invalid `font-family` rule, which is fixed by this pull request.