### PR TITLE
fix loading of language files

### DIFF
--- a/cookiebar-latest.js
+++ b/cookiebar-latest.js
@@ -162,7 +162,7 @@ function setupCookieBar() {
 
     // Load the correct language messages file and set some variables
     var request = new XMLHttpRequest();
-    request.open('GET', path + '/lang/' + userLang + '.html', true);
+    request.open('GET', path + 'lang/' + userLang + '.html', true);
     request.onreadystatechange = function() {
       if (request.readyState === 4 && request.status === 200) {
         var element = document.createElement('div');


### PR DESCRIPTION
In some cases the language files are not correctly loaded, because the constructed URL contains two consecutive slashes. For example your example installation at [cookie-bar.eu](http://cookie-bar.eu) loads the german language from the following URL (according to my network monitor):

`http://cookie-bar.eu//lang/de.html`

In my current case, your JS script file is served through a web application within a servlet container. This environment does not handle URL's with two consecutive slashes in the same way like a normal Apache webserver would do. The servlet container returns a 404 error code for these URL's.

Therefore I'm proposing this puil request. It fixes the created URL for language files, that no consecutive slashes are used. With this modification the URL to the german language files would look like

`http://cookie-bar.eu/lang/de.html`