### PR TITLE
Update de.html confirm button text mismatch bugfix

### DIFF
--- a/lang/de.html
+++ b/lang/de.html
@@ -18,7 +18,7 @@
             <i id='cookie-bar-privacy-page'>
 			<br>Lesen Sie bitte unsere <a rel='nofollow' id='cookie-bar-privacy-link' href=''>Datenschutzrichtlinie</a>, um mehr darüber zu erfahren, wie diese Internetseite Cookies und lokalen Speicher nutzt.<br><br></i>
 
-            <br>Durch das Klicken von <span>Cookies erlauben</span>, <span id='cookie-bar-scrolling'>oder indem Sie durch die Seite scrollen,</span>  geben Sie dieser Internetseite die Erlaubnis, Informationen in Form von Cookies auf Ihrem Gerät zu speichern.
+            <br>Durch das Klicken von <span>Verstanden</span>, <span id='cookie-bar-scrolling'>oder indem Sie durch die Seite scrollen,</span>  geben Sie dieser Internetseite die Erlaubnis, Informationen in Form von Cookies auf Ihrem Gerät zu speichern.
             <i id='cookie-bar-no-consent'>
             <br>
             <br>Durch das Klicken von <span>Cookies verbieten</span> verweigern Sie Ihre Zustimmung, Cookies oder lokalen Speicher zu nutzen. Weiterhin werden alle Cookies und lokal gespeicherte Daten gelöscht und Teile der Internetseite könnten aufhören, ordnungsgemäß zu funktionieren.</i><br>


### PR DESCRIPTION
Through commit [96208f3](https://github.com/ToX82/cookie-bar/commit/96208f3f19f410f4f36b818bd2bdb9e9fbefaa74) the button text changed from 'Cookies erlauben' to 'Verstanden' which wasn't reflected in the details text. So I fixed this so both are named equally now to not confuse the users.

[Ref to the discussion where the bug happend](https://github.com/ToX82/cookie-bar/pull/50)