### PR TITLE
Change info link to UODO

### DIFF
--- a/lang/pl.html
+++ b/lang/pl.html
@@ -40,7 +40,7 @@
             <br>
             <br>Klikając <span>Nie zezwalaj</span>, <span id='cookie-bar-scrolling'>lub przewijając stronę,</span> nie wyrażasz zgody na przechowywanie jakichkolwiek plików cookie i danych lokacyjnych dla tej witryny, ostatecznie usuwając już zapisane pliki cookie (niektóre elementy witryny mogą przestać działać poprawnie).</i>
             <br>
-            <br>Aby dowiedzieć się więcej na temat przechowywania plików cookie, odwiedź <a rel='nofollow noopener noreferrer' target='_blank' href='http://www.giodo.gov.pl/169/id_art/1026/j/pl/'>GIODO</a>.
+            <br>Aby dowiedzieć się więcej na temat przechowywania plików cookie, odwiedź <a rel='nofollow noopener noreferrer' target='_blank' href='https://uodo.gov.pl/pl/1/255'>UODO</a>.
             <hr> Aby wyłączyć wszystkie pliki cookie za pośrednictwem przeglądarki, kliknij odpowiednią ikonę i postępuj zgodnie z instrukcjami.
             <br>
             <br>


### PR DESCRIPTION
From may 2018 there is new office in Poland responsible for cookie law - UODO (recently GIODO).
